### PR TITLE
fix: gists with an unknown language will fallback to plaintext

### DIFF
--- a/src/theme/GistPage/index.tsx
+++ b/src/theme/GistPage/index.tsx
@@ -23,7 +23,7 @@ const GistPage = ({ gist }: Props) => {
   return (
     <GistLayout>
       {Object.values(files!).map((file, index) => {
-        const language = mapGitHubLanguageToPrismLanguage(file!.language!)
+        const language = file?.language && mapGitHubLanguageToPrismLanguage(file.language)
 
         return (
           <div key={file!.filename} className={styles.file}>


### PR DESCRIPTION
#### Changes

- Made it so that when GitHub doesn't detect a language, the parsing will be skipped and the CodeBlock will render plain-text

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution
      [guide](https://github.com/webbertakken/docusaurus-plugin-content-gists/blob/main/CONTRIBUTING.md)
      and accept the
      [code](https://github.com/webbertakken/docusaurus-plugin-content-gists/blob/main/CODE_OF_CONDUCT.md)
      of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
